### PR TITLE
Added support for batch_get across tables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   - TOXENV=py34
   - TOXENV=py35
 install:
-  - pip install tox coveralls --use-mirrors
+  - pip install tox coveralls
 script: tox
 after_success:
   if [ "$TOXENV" == "py27" ]; then coveralls; fi


### PR DESCRIPTION
**This is incomplete**

Added support for batch_get across tables, but would like input of a number of things I wasn't sure about:

- Handling more then 100 keys
- Fetching unprocessed keys

I wrote this as a first step in getting support for something akin to [relationships](http://docs.sqlalchemy.org/en/rel_1_1/orm/relationships.html) in Flywheel.